### PR TITLE
Correct the MD5 Hash for built roms

### DIFF
--- a/ages.md5
+++ b/ages.md5
@@ -1,1 +1,1 @@
-c4639cc61c049e5a085526bb6cac03bb *ages.gbc
+719a93b13f00322f3bc33cfd585f7b41 *ages.gbc

--- a/seasons.md5
+++ b/seasons.md5
@@ -1,1 +1,1 @@
-f2dc6c4e093e4f8c6cbea80e8dbd62cb  seasons.gbc
+b46c2bc072d1aa165ea1371333dd5def  seasons.gbc


### PR DESCRIPTION
Hey Shadow I corrected the .md5 hash files for when the Makefile assembles the roms and verifies the checksum to the correct one!